### PR TITLE
test: make version test dynamic instead of hardcoded

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawn } from "bun";
+import packageJson from "../package.json" with { type: "json" };
 
 let testDir: string;
 const cliPath = join(import.meta.dir, "index.ts");
@@ -201,7 +202,7 @@ describe("CLI", () => {
     await proc.exited;
 
     expect(proc.exitCode).toBe(0);
-    expect(output).toContain("0.1.0");
+    expect(output).toContain(packageJson.version);
   });
 
   test("shows output path in default mode", async () => {


### PR DESCRIPTION
## Summary
- Fixed failing test in PR #3 by making version test dynamic
- Test now reads version from package.json instead of hardcoding "0.1.0"
- Prevents future test failures when version changes

## Test plan
- [x] Run `bun test` to verify all tests pass
- [x] Run `bun run ci` to ensure no other issues
- [x] Verify test passes with current version (0.1.0)

🤖 Generated with [Claude Code](https://claude.ai/code)