### PR TITLE
fix: remove --yes flag from npx command in GitHub Action

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -9,6 +9,8 @@
 [![npm Release](https://github.com/sugurutakahashi-1234/mermaid-markdown-wrap/actions/workflows/cd-npm-release.yml/badge.svg)](https://github.com/sugurutakahashi-1234/mermaid-markdown-wrap/actions/workflows/cd-npm-release.yml)
 [![GitHub Release Date](https://img.shields.io/github/release-date/sugurutakahashi-1234/mermaid-markdown-wrap)](https://github.com/sugurutakahashi-1234/mermaid-markdown-wrap/releases)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/sugurutakahashi-1234/mermaid-markdown-wrap/pulls)
+[![GitHub Marketplace](https://img.shields.io/badge/marketplace-mermaid--markdown--wrap-blue?style=flat&logo=github)](https://github.com/marketplace/actions/mermaid-markdown-wrap)
+[![Used by](https://img.shields.io/static/v1?label=Used%20by&message=0%20repositories&color=informational&logo=github)](https://github.com/sugurutakahashi-1234/mermaid-markdown-wrap/network/dependents)
 
 [English](README.md) | [日本語](README.ja.md)
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 [![npm Release](https://github.com/sugurutakahashi-1234/mermaid-markdown-wrap/actions/workflows/cd-npm-release.yml/badge.svg)](https://github.com/sugurutakahashi-1234/mermaid-markdown-wrap/actions/workflows/cd-npm-release.yml)
 [![GitHub Release Date](https://img.shields.io/github/release-date/sugurutakahashi-1234/mermaid-markdown-wrap)](https://github.com/sugurutakahashi-1234/mermaid-markdown-wrap/releases)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/sugurutakahashi-1234/mermaid-markdown-wrap/pulls)
+[![GitHub Marketplace](https://img.shields.io/badge/marketplace-mermaid--markdown--wrap-blue?style=flat&logo=github)](https://github.com/marketplace/actions/mermaid-markdown-wrap)
+[![Used by](https://img.shields.io/static/v1?label=Used%20by&message=0%20repositories&color=informational&logo=github)](https://github.com/sugurutakahashi-1234/mermaid-markdown-wrap/network/dependents)
 
 [English](README.md) | [日本語](README.ja.md)
 

--- a/action.yml
+++ b/action.yml
@@ -102,7 +102,7 @@ runs:
         [[ "${{ inputs.hide-command }}" == "true" ]] && args+=(--hide-command)
         
         # Run with JSON output and save to file
-        npx --yes mermaid-markdown-wrap "${args[@]}" --log-format json > conversion-results.json
+        npx mermaid-markdown-wrap "${args[@]}" --log-format json > conversion-results.json
         
         # Display results
         cat conversion-results.json


### PR DESCRIPTION
## Summary
- Removed the `--yes` flag from npx command in GitHub Action that was causing execution failures
- Simplified to use `npx mermaid-markdown-wrap` without any flags

## Test plan
- [ ] GitHub Actions integration tests should pass
- [ ] The action should successfully execute `npx mermaid-markdown-wrap` command

🤖 Generated with [Claude Code](https://claude.ai/code)