### PR TITLE
chore: add debug information for GitHub Action npx issue

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,6 +84,22 @@ runs:
       with:
         node-version: '20'
     
+    - name: Debug npm/npx environment
+      shell: bash
+      run: |
+        echo "=== Debug Information ==="
+        echo "Node version: $(node --version)"
+        echo "npm version: $(npm --version)"
+        echo "npx version: $(npx --version)"
+        echo "Which npx: $(which npx)"
+        echo "npm registry: $(npm config get registry)"
+        echo ""
+        echo "=== Checking package availability ==="
+        npm view mermaid-markdown-wrap version || echo "Package not found in registry"
+        echo ""
+        echo "=== Testing npx execution ==="
+        npx mermaid-markdown-wrap --version || echo "npx execution failed"
+    
     - name: Run mermaid-markdown-wrap
       id: convert
       shell: bash


### PR DESCRIPTION
## Summary
- Added diagnostic step to investigate why npx fails with "mermaid-markdown-wrap: command not found" error
- This PR adds debug information before the actual execution to help diagnose the issue

## Debug information collected:
- Node.js, npm, and npx versions
- npm registry configuration
- Package availability check
- Direct npx execution test

## Related to
- Previous PR #8 attempted to fix by removing `--yes` flag but the issue persists

## Test plan
- [ ] GitHub Actions should run and show debug information
- [ ] The debug output will help identify the root cause

🤖 Generated with [Claude Code](https://claude.ai/code)