### PR TITLE
fix: use source code for PRs to main branch in CI tests

### DIFF
--- a/.github/workflows/ci-test-action-marketplace.yml
+++ b/.github/workflows/ci-test-action-marketplace.yml
@@ -16,6 +16,11 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - '.release-please-manifest.json'
+  push:
+    branches:
+      - main
+    paths:
+      - '.release-please-manifest.json'
   workflow_dispatch:
 
 jobs:

--- a/action.yml
+++ b/action.yml
@@ -122,9 +122,16 @@ runs:
         [[ "${{ inputs.hide-command }}" == "true" ]] && args+=(--hide-command)
         
         # Run with JSON output and exit on failure
-        if [[ "${{ inputs.local-test }}" == "true" ]]; then
-          # Local test mode: run TypeScript directly with bun
-          echo "Running in local test mode - using current source code"
+        if [[ "${{ inputs.local-test }}" == "true" ]] || \
+           [[ "${{ github.event_name }}" == "pull_request" && \
+              "${{ github.repository }}" == "sugurutakahashi-1234/mermaid-markdown-wrap" && \
+              "${{ github.base_ref }}" == "main" ]]; then
+          # Use current source code
+          if [[ "${{ inputs.local-test }}" == "true" ]]; then
+            echo "Running in local test mode - using current source code"
+          else
+            echo "Running PR test for main branch - using current source code"
+          fi
           bun install
           if ! bun run src/index.ts "${args[@]}" --log-format json > conversion-results.json; then
             echo "Error: mermaid-markdown-wrap command failed"


### PR DESCRIPTION
## Summary

This PR fixes the CI test failures caused by the npm package not being updated with the latest changes.

## Changes

1. **Modified action.yml**:
   - Added condition to use current source code when PR targets main branch
   - Refactored duplicate code using OR condition
   - Keeps existing  behavior intact

2. **Modified ci-test-action-marketplace.yml**:
   - Added push event trigger for main branch
   - This allows testing both scenarios:
     - PR: Uses source code (pre-release testing)
     - Push: Uses npm package (post-release validation)

## Why this change?

The CI tests were failing because they were using , which pulls from npm. However, the npm package (v1.1.0) doesn't include the recent `changed` property implementation, causing tests to fail with `changed: undefined`.

This change ensures:
- ✅ PRs to main branch test against the actual code being merged
- ✅ Push events validate the published npm package works correctly
- ✅ No impact on external users of the GitHub Action

## Test Plan

1. This PR itself will test the new behavior
2. After merge, the push event will validate npm package functionality