### PR TITLE
feat: trigger test workflows after npm release via workflow_run event

### DIFF
--- a/.github/workflows/ci-test-action-marketplace.yml
+++ b/.github/workflows/ci-test-action-marketplace.yml
@@ -16,12 +16,13 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - '.release-please-manifest.json'
-  push:
-    branches:
-      - main
-    paths:
-      - '.release-please-manifest.json'
   workflow_dispatch:
+  workflow_run:
+    # Triggered when npm Release workflow completes
+    # Note: This requires the workflow name to match exactly with the 'name' field in cd-npm-release.yml
+    workflows: ["npm Release"]
+    types:
+      - completed
 
 jobs:
   # Basic usage - Verify basic mermaid wrapping functionality

--- a/.github/workflows/ci-test-published-package.yml
+++ b/.github/workflows/ci-test-published-package.yml
@@ -1,12 +1,13 @@
 name: Published Tests
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - '.release-please-manifest.json'
   workflow_dispatch:
+  workflow_run:
+    # Triggered when npm Release workflow completes
+    # Note: This requires the workflow name to match exactly with the 'name' field in cd-npm-release.yml
+    workflows: ["npm Release"]
+    types:
+      - completed
 
 jobs:
   # Test the latest published version with npx


### PR DESCRIPTION
## Summary
- Add `workflow_run` trigger to automatically run tests after npm package release
- Both `ci-test-action-marketplace.yml` and `ci-test-published-package.yml` now trigger when `npm Release` workflow completes
- Use GitHub's native workflow chaining instead of manual triggering with GitHub CLI

## Changes
- Add `workflow_run` event trigger to both test workflows
- Add explanatory comments about workflow name dependency
- Simplify `if` conditions to use `always()` for summary jobs
- Remove previously added manual trigger jobs from `cd-npm-release.yml`

## Benefits
- Better visibility of workflow dependencies in GitHub Actions UI
- Easier debugging and tracking of workflow chains
- More "GitHub-native" approach using built-in features

## Test plan
- [ ] Verify workflows trigger correctly after npm release
- [ ] Check that workflow dependencies are visible in GitHub Actions UI
- [ ] Confirm tests run successfully when triggered by workflow_run

🤖 Generated with [Claude Code](https://claude.ai/code)