### PR TITLE
ci: update action version to v1.2.0 in test workflow

### DIFF
--- a/.github/workflows/ci-test-published-package.yml
+++ b/.github/workflows/ci-test-published-package.yml
@@ -54,7 +54,7 @@ jobs:
       
       # x-release-please-start-version
       - name: Use published action
-        uses: sugurutakahashi-1234/mermaid-markdown-wrap@v1.0.0
+        uses: sugurutakahashi-1234/mermaid-markdown-wrap@v1.2.0
         with:
           input: 'test.mmd'
       # x-release-please-end


### PR DESCRIPTION
## Summary
- Update mermaid-markdown-wrap action version from v1.0.0 to v1.2.0 in the published package test workflow

## Why
The test workflow was using an outdated version (v1.0.0) while the current latest version is v1.2.0. This ensures tests run against the latest stable version.

## Changes
- Updated action version in `.github/workflows/ci-test-published-package.yml`

## Test plan
- [ ] CI tests pass with the updated version
- [ ] The published package test workflow runs successfully

🤖 Generated with [Claude Code](https://claude.ai/code)