### PR TITLE
fix: add id-token permission for release-please workflow

### DIFF
--- a/.github/workflows/cd-npm-release.yml
+++ b/.github/workflows/cd-npm-release.yml
@@ -10,10 +10,11 @@ on:
       - main
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  packages: write
+  contents: write       # Required for creating release tags and GitHub releases
+  pull-requests: write  # Required for creating and updating release PRs
+  issues: write         # Required for commenting on PRs
+  packages: write       # Required for publishing npm packages
+  id-token: write       # Required for updating workflow files (extra-files feature)
 
 jobs:
   cd-npm-release:

--- a/package.json
+++ b/package.json
@@ -85,8 +85,6 @@
     "clean:install": "bun run clean && bun install",
     "clean:build": "bun run clean:install && bun run ci",
     "release-please:dry-run": "bunx release-please release-pr --token=$(gh auth token) --repo-url=sugurutakahashi-1234/mermaid-markdown-wrap --debug --dry-run",
-    "release-please:list": "git ls-remote --heads origin | grep release-please--branches--main--components--mermaid-markdown-wrap || echo 'No release-please branches found'",
-    "release-please:cleanup": "git push origin --delete release-please--branches--main--components--mermaid-markdown-wrap || true",
     "deps:check": "bunx ncu --deep",
     "deps:update": "bunx ncu -u --deep && bun install && bun run ci"
   },


### PR DESCRIPTION
## Summary
- Add `id-token: write` permission to fix release-please workflow errors
- Add explanatory comments for all permissions in cd-npm-release.yml
- Remove unused release-please scripts from package.json

## Context
The release-please action was failing with "Error adding to tree" when trying to update workflow files specified in the `extra-files` configuration. This was due to missing `id-token: write` permission required for updating GitHub workflow files.

## Changes
- Added `id-token: write` permission to `.github/workflows/cd-npm-release.yml`
- Added comments explaining what each permission is used for
- Removed `release-please:list` and `release-please:cleanup` scripts from package.json as they are no longer needed

## Test plan
- [x] Run `bun run ci` to verify all checks pass
- [ ] After merge, verify that release-please can successfully create PRs without errors

🤖 Generated with [Claude Code](https://claude.ai/code)