### PR TITLE
fix: remove workflow files from release-please extra-files

### DIFF
--- a/.github/workflows/cd-npm-release.yml
+++ b/.github/workflows/cd-npm-release.yml
@@ -14,7 +14,6 @@ permissions:
   pull-requests: write  # Required for creating and updating release PRs
   issues: write         # Required for commenting on PRs
   packages: write       # Required for publishing npm packages
-  id-token: write       # Required for updating workflow files (extra-files feature)
 
 jobs:
   cd-npm-release:

--- a/.github/workflows/ci-test-published-package.yml
+++ b/.github/workflows/ci-test-published-package.yml
@@ -52,12 +52,10 @@ jobs:
           echo "graph TD" > test.mmd
           echo "A-->B" >> test.mmd
       
-      # x-release-please-start-version
       - name: Use published action
-        uses: sugurutakahashi-1234/mermaid-markdown-wrap@v1.2.0
+        uses: sugurutakahashi-1234/mermaid-markdown-wrap@main
         with:
           input: 'test.mmd'
-      # x-release-please-end
       
       - name: Verify action output
         run: |

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "clean": "rm -rf bun.lock node_modules dist coverage .*.bun-build tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "clean:install": "bun run clean && bun install",
     "clean:build": "bun run clean:install && bun run ci",
-    "release-please:dry-run": "bunx release-please release-pr --token=$(gh auth token) --repo-url=sugurutakahashi-1234/mermaid-markdown-wrap --debug --dry-run",
+    "release-please:dry-run": "bunx release-please release-pr --token=$(gh auth token) --repo-url=$(gh repo view --json nameWithOwner --jq '.nameWithOwner') --debug --dry-run",
     "deps:check": "bunx ncu --deep",
     "deps:update": "bunx ncu -u --deep && bun install && bun run ci"
   },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -35,10 +35,6 @@
         {
           "type": "generic",
           "path": "README.ja.md"
-        },
-        {
-          "type": "generic",
-          "path": ".github/workflows/ci-test-published-package.yml"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Remove workflow files from release-please extra-files configuration to fix "Error adding to tree" error
- Remove unnecessary id-token permission
- Update ci-test-published-package.yml to use @main instead of version tags

## Problem
Release-please was failing with "Error adding to tree" when trying to update `.github/workflows/ci-test-published-package.yml` through the extra-files configuration. This is because GitHub workflow files are not supported by release-please's extra-files feature due to security restrictions.

## Solution
1. Removed `.github/workflows/ci-test-published-package.yml` from `release-please-config.json`
2. Removed `id-token: write` permission that was added for workflow file updates
3. Changed the action reference in `ci-test-published-package.yml` from `@v1.2.0` to `@main` to eliminate the need for version updates

## Test plan
- [x] Run `bun run ci` to verify all checks pass
- [ ] After merge, verify that release-please can successfully create PRs without "Error adding to tree" errors
- [ ] Verify that ci-test-published-package.yml works correctly with @main reference

## Related Issues
- Fixes the "Error adding to tree" error reported in googleapis/release-please-action#938

🤖 Generated with [Claude Code](https://claude.ai/code)